### PR TITLE
Fixes for downloads/setup on Mac

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the "zephyr-tools" extension will be documented in this file.
 
+### [0.2.2]
+
+Changed:
+
+- Updated MD5 hashes for Mac downloads
+- Fixed issue of toolchain setup requiring cmake before cmake is installed
+
 ### [0.2.1]
 
 Changed:

--- a/manifest/manifest.json
+++ b/manifest/manifest.json
@@ -112,7 +112,7 @@
                     "name": "zephyr-tools",
                     "filename": "zephyr-tools-0.1.7-x86_64-apple-darwin.tar.gz",
                     "url": "https://github.com/circuitdojo/zephyr-tools-cli/releases/download/0.1.7/zephyr-tools-0.1.7-x86_64-apple-darwin.tar.gz",
-                    "md5": "cc6008e13fc6e51cee3aa2f6afcb9087"
+                    "md5": "a2eaad10e8f4e29708a9bfe4193a61ed"
                 },
                 {
                     "name": "newtmgr",
@@ -139,9 +139,10 @@
                     "name": "zephyr-sdk-0.16.4 (latest)",
                     "downloads": [
                         {
+                            "name": "toolchain",
                             "filename": "zephyr-sdk-0.16.4_macos-x86_64_minimal.tar.xz",
                             "url": "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.4/zephyr-sdk-0.16.4_macos-x86_64_minimal.tar.xz",
-                            "md5": "2e6900c9ea1d03fbf67cd784e18f53bf",
+                            "md5": "4771443abfc72c1442a2cdf01034ab95",
                             "suffix": "zephyr-sdk-0.16.4/arm-zephyr-eabi/bin/",
                             "env": [
                                 {
@@ -170,6 +171,7 @@
                     "name": "zephyr-sdk-0.15.1",
                     "downloads": [
                         {
+                            "name": "toolchain",
                             "filename": "zephyr-sdk-0.15.1_macos-x86_64_minimal.tar.gz",
                             "url": "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.1/zephyr-sdk-0.15.1_macos-x86_64_minimal.tar.gz",
                             "md5": "2e6900c9ea1d03fbf67cd784e18f53bf",
@@ -206,7 +208,7 @@
                     "name": "zephyr-tools",
                     "filename": "zephyr-tools-0.1.7-aarch64-apple-darwin.tar.gz",
                     "url": "https://github.com/circuitdojo/zephyr-tools-cli/releases/download/0.1.7/zephyr-tools-0.1.7-aarch64-apple-darwin.tar.gz",
-                    "md5": "9505f60901af7781f95dfa36fedb9fcd"
+                    "md5": "8649a82eb65f83d90b937d3065764bbc"
                 },
                 {
                     "name": "newtmgr",
@@ -227,9 +229,10 @@
                     "name": "zephyr-sdk-0.16.4 (latest)",
                     "downloads": [
                         {
+                            "name": "toolchain",
                             "filename": "zephyr-sdk-0.16.4_macos-aarch64_minimal.tar.xz",
                             "url": "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.4/zephyr-sdk-0.16.4_macos-aarch64_minimal.tar.xz",
-                            "md5": "6b0d6e08ad5753a29d96df4d6ccfed72",
+                            "md5": "4aa2aa3b8313e04dd93a8bbee4b31754",
                             "suffix": "zephyr-sdk-0.16.4/arm-zephyr-eabi/bin/",
                             "env": [
                                 {
@@ -258,6 +261,7 @@
                     "name": "zephyr-sdk-0.15.1",
                     "downloads": [
                         {
+                            "name": "toolchain",
                             "filename": "zephyr-sdk-0.15.1_macos-aarch64_minimal.tar.gz",
                             "url": "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.1/zephyr-sdk-0.15.1_macos-aarch64_minimal.tar.gz",
                             "md5": "6b0d6e08ad5753a29d96df4d6ccfed72",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "zephyr-tools",
   "displayName": "Circuit Dojo Zephyr SDK Tools",
   "description": "Used for building your Zephyr projects.",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "license": "Apache-2.0",
   "publisher": "circuitdojo",
   "icon": "img/bulb.png",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -251,16 +251,16 @@ export async function activate(context: vscode.ExtensionContext) {
                 return;
               }
 
-              // Output indicating toolchain install
-              output.appendLine(`[SETUP] Installing ${entry.name} toolchain...`);
-
-              for (var download of entry.downloads) {
+              for (var download of element.downloads) {
                 // Process download entry
                 await process_download(download, context);
                 progress.report({ increment: 5 });
               }
 
-              for (var download of element.downloads) {
+              // Output indicating toolchain install
+              output.appendLine(`[SETUP] Installing ${entry.name} toolchain...`);
+
+              for (var download of entry.downloads) {
                 // Process download entry
                 await process_download(download, context);
                 progress.report({ increment: 5 });
@@ -1743,7 +1743,7 @@ async function process_download(download: ManifestDownloadEntry, context: vscode
 
     // Check again
     if ((await FileDownload.check(download.filename, download.md5)) === false) {
-      vscode.window.showErrorMessage("Error downloading " + download.filename + ". Check output for more info.");
+      vscode.window.showErrorMessage("Error downloading " + download.filename + ". Checksum mismatch.");
       return;
     }
   }


### PR DESCRIPTION
- Updated MD5 hashes for Mac downloads
- Fixed issue of toolchain setup requiring cmake before cmake is installed