### PR TITLE
Manifest update for windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the "zephyr-tools" extension will be documented in this file.
 
+### [0.2.3]
+
+Changed:
+
+- Fixed manifest entries for Windows
+- Added 7z support
+- Updating pkg dependencies
+- `process_download` now returns to avoid continuing if error
+
 ### [0.2.2]
 
 Changed:

--- a/manifest/manifest.json
+++ b/manifest/manifest.json
@@ -1,399 +1,399 @@
 {
-    "version": 13,
-    "win32": [
+  "version": 13,
+  "win32": [
+    {
+      "arch": "x64",
+      "downloads": [
         {
-            "arch": "x64",
-            "downloads": [
-                {
-                    "name": "zephyr-tools",
-                    "filename": "zephyr-tools-0.1.7-x86_64-pc-windows-msvc.zip",
-                    "url": "https://github.com/circuitdojo/zephyr-tools-cli/releases/download/0.1.7/zephyr-tools-0.1.7-x86_64-pc-windows-msvc.zip",
-                    "md5": "3d3504f84fe98e645b27fb6c63e761fa"
-                },
-                {
-                    "name": "newtmgr",
-                    "filename": "newtmgr.zip",
-                    "url": "https://docs.jaredwolff.com/files/newtmgr/windows/newtmgr.zip",
-                    "md5": "3ed9e43ff509a54fd5010c144e45697b"
-                },
-                {
-                    "name": "ninja",
-                    "filename": "ninja-win.zip",
-                    "url": "https://github.com/ninja-build/ninja/releases/download/v1.10.2/ninja-win.zip",
-                    "md5": "8dad6a63141d57aae277e68ef7658ca1"
-                },
-                {
-                    "name": "cmake",
-                    "filename": "cmake-3.22.0-windows-x86_64.zip",
-                    "url": "https://github.com/Kitware/CMake/releases/download/v3.22.0/cmake-3.22.0-windows-x86_64.zip",
-                    "md5": "1a273903dcb295455b69af7c9c10efa2",
-                    "suffix": "cmake-3.22.0-windows-x86_64\\bin\\"
-                }
-            ],
-            "toolchains": [
-                {
-                    "name": "zephyr-sdk-0.16.4 (latest)",
-                    "downloads": [
-                        {
-                            "name": "toolchain",
-                            "filename": "zephyr-sdk-0.16.4_windows-x86_64_minimal.zip",
-                            "url": "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.4/zephyr-sdk-0.16.4_windows-x86_64_minimal.zip",
-                            "md5": "4c73427373995d1ac53412383a2f6610",
-                            "suffix": "zephyr-sdk-0.16.4\\arm-zephyr-eabi\\bin\\",
-                            "env": [
-                                {
-                                    "name": "ZEPHYR_TOOLCHAIN_VARIANT",
-                                    "value": "zephyr",
-                                    "usepath": false,
-                                    "append": false
-                                },
-                                {
-                                    "name": "ZEPHYR_SDK_INSTALL_DIR",
-                                    "suffix": "zephyr-sdk-0.16.4",
-                                    "usepath": true,
-                                    "append": false
-                                }
-                            ]
-                        },
-                        {
-                            "name": "toolchain",
-                            "filename": "toolchain_windows-x86_64_arm-zephyr-eabi.zip",
-                            "url": "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.4/toolchain_windows-x86_64_arm-zephyr-eabi.zip",
-                            "md5": "1786d58c03f3e380d683b1e5ded45131",
-                            "suffix": "zephyr-sdk-0.16.4\\arm-zephyr-eabi\\bin\\",
-                            "clear_target": false,
-                            "copy_to_subfolder": "zephyr-sdk-0.16.4"
-                        }
-                    ]
-                },
-                {
-                    "name": "zephyr-sdk-0.15.1",
-                    "downloads": [
-                        {
-                            "name": "toolchain",
-                            "filename": "zephyr-sdk-0.15.1_windows-x86_64_minimal.zip",
-                            "url": "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.1/zephyr-sdk-0.15.1_windows-x86_64_minimal.zip",
-                            "md5": "4c73427373995d1ac53412383a2f6610",
-                            "suffix": "zephyr-sdk-0.15.1\\arm-zephyr-eabi\\bin\\",
-                            "env": [
-                                {
-                                    "name": "ZEPHYR_TOOLCHAIN_VARIANT",
-                                    "value": "zephyr",
-                                    "usepath": false,
-                                    "append": false
-                                },
-                                {
-                                    "name": "ZEPHYR_SDK_INSTALL_DIR",
-                                    "suffix": "zephyr-sdk-0.15.1",
-                                    "usepath": true,
-                                    "append": false
-                                }
-                            ]
-                        },
-                        {
-                            "name": "toolchain",
-                            "filename": "toolchain_windows-x86_64_arm-zephyr-eabi.zip",
-                            "url": "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.1/toolchain_windows-x86_64_arm-zephyr-eabi.zip",
-                            "md5": "1786d58c03f3e380d683b1e5ded45131",
-                            "suffix": "zephyr-sdk-0.15.1\\arm-zephyr-eabi\\bin\\",
-                            "clear_target": false,
-                            "copy_to_subfolder": "zephyr-sdk-0.15.1"
-                        }
-                    ]
-                }
-            ]
-        }
-    ],
-    "darwin": [
-        {
-            "arch": "x64",
-            "downloads": [
-                {
-                    "name": "zephyr-tools",
-                    "filename": "zephyr-tools-0.1.7-x86_64-apple-darwin.tar.gz",
-                    "url": "https://github.com/circuitdojo/zephyr-tools-cli/releases/download/0.1.7/zephyr-tools-0.1.7-x86_64-apple-darwin.tar.gz",
-                    "md5": "a2eaad10e8f4e29708a9bfe4193a61ed"
-                },
-                {
-                    "name": "newtmgr",
-                    "filename": "newtmgr.zip",
-                    "url": "https://docs.jaredwolff.com/files/newtmgr/darwin/newtmgr.zip",
-                    "md5": "7a707d8e518d46d92758a7b1b87366ed"
-                },
-                {
-                    "name": "ninja",
-                    "filename": "ninja-mac.zip",
-                    "url": "https://github.com/ninja-build/ninja/releases/download/v1.10.2/ninja-mac.zip",
-                    "md5": "4ac3da15e1ace3a0f846021e018a3acd"
-                },
-                {
-                    "name": "cmake",
-                    "filename": "cmake-3.22.0-macos-universal.tar.gz",
-                    "url": "https://github.com/Kitware/CMake/releases/download/v3.22.0/cmake-3.22.0-macos-universal.tar.gz",
-                    "md5": "438fc508b37b70a1d1bb112a4ffd4ad7",
-                    "suffix": "cmake-3.22.0-macos-universal/CMake.app/Contents/bin/"
-                }
-            ],
-            "toolchains": [
-                {
-                    "name": "zephyr-sdk-0.16.4 (latest)",
-                    "downloads": [
-                        {
-                            "name": "toolchain",
-                            "filename": "zephyr-sdk-0.16.4_macos-x86_64_minimal.tar.xz",
-                            "url": "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.4/zephyr-sdk-0.16.4_macos-x86_64_minimal.tar.xz",
-                            "md5": "4771443abfc72c1442a2cdf01034ab95",
-                            "suffix": "zephyr-sdk-0.16.4/arm-zephyr-eabi/bin/",
-                            "env": [
-                                {
-                                    "name": "ZEPHYR_TOOLCHAIN_VARIANT",
-                                    "value": "zephyr",
-                                    "usepath": false,
-                                    "append": false
-                                },
-                                {
-                                    "name": "ZEPHYR_SDK_INSTALL_DIR",
-                                    "suffix": "zephyr-sdk-0.16.4",
-                                    "usepath": true,
-                                    "append": false
-                                }
-                            ],
-                            "cmd": [
-                                {
-                                    "cmd": "zephyr-sdk-0.16.4/setup.sh -t arm-zephyr-eabi",
-                                    "usepath": true
-                                }
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "name": "zephyr-sdk-0.15.1",
-                    "downloads": [
-                        {
-                            "name": "toolchain",
-                            "filename": "zephyr-sdk-0.15.1_macos-x86_64_minimal.tar.gz",
-                            "url": "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.1/zephyr-sdk-0.15.1_macos-x86_64_minimal.tar.gz",
-                            "md5": "2e6900c9ea1d03fbf67cd784e18f53bf",
-                            "suffix": "zephyr-sdk-0.15.1/arm-zephyr-eabi/bin/",
-                            "env": [
-                                {
-                                    "name": "ZEPHYR_TOOLCHAIN_VARIANT",
-                                    "value": "zephyr",
-                                    "usepath": false,
-                                    "append": false
-                                },
-                                {
-                                    "name": "ZEPHYR_SDK_INSTALL_DIR",
-                                    "suffix": "zephyr-sdk-0.15.1",
-                                    "usepath": true,
-                                    "append": false
-                                }
-                            ],
-                            "cmd": [
-                                {
-                                    "cmd": "zephyr-sdk-0.15.1/setup.sh -t arm-zephyr-eabi",
-                                    "usepath": true
-                                }
-                            ]
-                        }
-                    ]
-                }
-            ]
+          "name": "zephyr-tools",
+          "filename": "zephyr-tools-0.1.7-x86_64-pc-windows-msvc.zip",
+          "url": "https://github.com/circuitdojo/zephyr-tools-cli/releases/download/0.1.7/zephyr-tools-0.1.7-x86_64-pc-windows-msvc.zip",
+          "md5": "3d3504f84fe98e645b27fb6c63e761fa"
         },
         {
-            "arch": "arm64",
-            "downloads": [
-                {
-                    "name": "zephyr-tools",
-                    "filename": "zephyr-tools-0.1.7-aarch64-apple-darwin.tar.gz",
-                    "url": "https://github.com/circuitdojo/zephyr-tools-cli/releases/download/0.1.7/zephyr-tools-0.1.7-aarch64-apple-darwin.tar.gz",
-                    "md5": "8649a82eb65f83d90b937d3065764bbc"
-                },
-                {
-                    "name": "newtmgr",
-                    "filename": "newtmgr.zip",
-                    "url": "https://docs.jaredwolff.com/files/newtmgr/darwin/newtmgr.zip",
-                    "md5": "7a707d8e518d46d92758a7b1b87366ed"
-                },
-                {
-                    "name": "cmake",
-                    "filename": "cmake-3.22.0-macos-universal.tar.gz",
-                    "url": "https://github.com/Kitware/CMake/releases/download/v3.22.0/cmake-3.22.0-macos-universal.tar.gz",
-                    "md5": "438fc508b37b70a1d1bb112a4ffd4ad7",
-                    "suffix": "cmake-3.22.0-macos-universal/CMake.app/Contents/bin/"
-                }
-            ],
-            "toolchains": [
-                {
-                    "name": "zephyr-sdk-0.16.4 (latest)",
-                    "downloads": [
-                        {
-                            "name": "toolchain",
-                            "filename": "zephyr-sdk-0.16.4_macos-aarch64_minimal.tar.xz",
-                            "url": "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.4/zephyr-sdk-0.16.4_macos-aarch64_minimal.tar.xz",
-                            "md5": "4aa2aa3b8313e04dd93a8bbee4b31754",
-                            "suffix": "zephyr-sdk-0.16.4/arm-zephyr-eabi/bin/",
-                            "env": [
-                                {
-                                    "name": "ZEPHYR_TOOLCHAIN_VARIANT",
-                                    "value": "zephyr",
-                                    "usepath": false,
-                                    "append": false
-                                },
-                                {
-                                    "name": "ZEPHYR_SDK_INSTALL_DIR",
-                                    "suffix": "zephyr-sdk-0.16.4",
-                                    "usepath": true,
-                                    "append": false
-                                }
-                            ],
-                            "cmd": [
-                                {
-                                    "cmd": "zephyr-sdk-0.16.4/setup.sh -t arm-zephyr-eabi",
-                                    "usepath": true
-                                }
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "name": "zephyr-sdk-0.15.1",
-                    "downloads": [
-                        {
-                            "name": "toolchain",
-                            "filename": "zephyr-sdk-0.15.1_macos-aarch64_minimal.tar.gz",
-                            "url": "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.1/zephyr-sdk-0.15.1_macos-aarch64_minimal.tar.gz",
-                            "md5": "6b0d6e08ad5753a29d96df4d6ccfed72",
-                            "suffix": "zephyr-sdk-0.15.1/arm-zephyr-eabi/bin/",
-                            "env": [
-                                {
-                                    "name": "ZEPHYR_TOOLCHAIN_VARIANT",
-                                    "value": "zephyr",
-                                    "usepath": false,
-                                    "append": false
-                                },
-                                {
-                                    "name": "ZEPHYR_SDK_INSTALL_DIR",
-                                    "suffix": "zephyr-sdk-0.15.1",
-                                    "usepath": true,
-                                    "append": false
-                                }
-                            ],
-                            "cmd": [
-                                {
-                                    "cmd": "zephyr-sdk-0.15.1/setup.sh -t arm-zephyr-eabi",
-                                    "usepath": true
-                                }
-                            ]
-                        }
-                    ]
-                }
-            ]
-        }
-    ],
-    "linux": [
+          "name": "newtmgr",
+          "filename": "newtmgr.zip",
+          "url": "https://docs.jaredwolff.com/files/newtmgr/windows/newtmgr.zip",
+          "md5": "3ed9e43ff509a54fd5010c144e45697b"
+        },
         {
-            "arch": "x64",
-            "downloads": [
-                {
-                    "name": "zephyr-tools",
-                    "filename": "zephyr-tools-0.1.7-x86_64-unknown-linux-gnu.tar.gz",
-                    "url": "https://github.com/circuitdojo/zephyr-tools-cli/releases/download/0.1.7/zephyr-tools-0.1.7-x86_64-unknown-linux-gnu.tar.gz",
-                    "md5": "efca3005895e1437193b3b03f9abf561"
-                },
-                {
-                    "name": "newtmgr",
-                    "filename": "newtmgr.zip",
-                    "url": "https://docs.jaredwolff.com/files/newtmgr/linux/newtmgr.zip",
-                    "md5": "9900ec263d39264787903688cdefeed1"
-                },
-                {
-                    "name": "ninja",
-                    "filename": "ninja-linux.zip",
-                    "url": "https://github.com/ninja-build/ninja/releases/download/v1.10.2/ninja-linux.zip",
-                    "md5": "817e12e06e2463aeb5cb4e1d19ced606"
-                },
-                {
-                    "name": "cmake",
-                    "filename": "cmake-3.22.0-linux-x86_64.tar.gz",
-                    "url": "https://github.com/Kitware/CMake/releases/download/v3.22.0/cmake-3.22.0-linux-x86_64.tar.gz",
-                    "md5": "5537bbc683e364e5408a393a737f53a1",
-                    "suffix": "cmake-3.22.0-linux-x86_64/bin/"
-                }
-            ],
-            "toolchains": [
-                {
-                    "name": "zephyr-sdk-0.16.4 (latest)",
-                    "downloads": [
-                        {
-                            "name": "toolchain",
-                            "filename": "zephyr-sdk-0.16.4_linux-x86_64_minimal.tar.xz",
-                            "url": "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.4/zephyr-sdk-0.16.4_linux-x86_64_minimal.tar.xz",
-                            "md5": "5f10ac5111476d4e069b52f07aa3f4d5",
-                            "suffix": "zephyr-sdk-0.16.4/arm-zephyr-eabi/bin/",
-                            "env": [
-                                {
-                                    "name": "ZEPHYR_TOOLCHAIN_VARIANT",
-                                    "value": "zephyr",
-                                    "usepath": false,
-                                    "append": false
-                                },
-                                {
-                                    "name": "ZEPHYR_SDK_INSTALL_DIR",
-                                    "suffix": "zephyr-sdk-0.16.4",
-                                    "usepath": true,
-                                    "append": false
-                                }
-                            ]
-                        },
-                        {
-                            "name": "toolchain",
-                            "filename": "toolchain_linux-x86_64_arm-zephyr-eabi.tar.xz",
-                            "url": "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.4/toolchain_linux-x86_64_arm-zephyr-eabi.tar.xz",
-                            "md5": "4386d940c085670fc54480eb7eaebff8",
-                            "suffix": "zephyr-sdk-0.16.4\\arm-zephyr-eabi\\bin\\",
-                            "clear_target": false,
-                            "copy_to_subfolder": "zephyr-sdk-0.16.4"
-                        }
-                    ]
-                },
-                {
-                    "name": "zephyr-sdk-0.15.1",
-                    "downloads": [
-                        {
-                            "name": "toolchain",
-                            "filename": "zephyr-sdk-0.15.1_linux-x86_64_minimal.tar.gz",
-                            "url": "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.1/zephyr-sdk-0.15.1_linux-x86_64_minimal.tar.gz",
-                            "md5": "e74588785a291867feacf14134aaec61",
-                            "suffix": "zephyr-sdk-0.15.1/arm-zephyr-eabi/bin/",
-                            "env": [
-                                {
-                                    "name": "ZEPHYR_TOOLCHAIN_VARIANT",
-                                    "value": "zephyr",
-                                    "usepath": false,
-                                    "append": false
-                                },
-                                {
-                                    "name": "ZEPHYR_SDK_INSTALL_DIR",
-                                    "suffix": "zephyr-sdk-0.15.1",
-                                    "usepath": true,
-                                    "append": false
-                                }
-                            ]
-                        },
-                        {
-                            "name": "toolchain",
-                            "filename": "toolchain_linux-x86_64_arm-zephyr-eabi.tar.gz",
-                            "url": "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.1/toolchain_linux-x86_64_arm-zephyr-eabi.tar.gz",
-                            "md5": "bf75b7db76bd5ad260be7e708e29c90d",
-                            "suffix": "zephyr-sdk-0.15.1\\arm-zephyr-eabi\\bin\\",
-                            "clear_target": false,
-                            "copy_to_subfolder": "zephyr-sdk-0.15.1"
-                        }
-                    ]
-                }
-            ]
+          "name": "ninja",
+          "filename": "ninja-win.zip",
+          "url": "https://github.com/ninja-build/ninja/releases/download/v1.10.2/ninja-win.zip",
+          "md5": "8dad6a63141d57aae277e68ef7658ca1"
+        },
+        {
+          "name": "cmake",
+          "filename": "cmake-3.22.0-windows-x86_64.zip",
+          "url": "https://github.com/Kitware/CMake/releases/download/v3.22.0/cmake-3.22.0-windows-x86_64.zip",
+          "md5": "1a273903dcb295455b69af7c9c10efa2",
+          "suffix": "cmake-3.22.0-windows-x86_64\\bin\\"
         }
-    ]
+      ],
+      "toolchains": [
+        {
+          "name": "zephyr-sdk-0.16.4 (latest)",
+          "downloads": [
+            {
+              "name": "toolchain",
+              "filename": "zephyr-sdk-0.16.4_windows-x86_64_minimal.zip",
+              "url": "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.4/zephyr-sdk-0.16.4_windows-x86_64_minimal.zip",
+              "md5": "4c73427373995d1ac53412383a2f6610",
+              "suffix": "zephyr-sdk-0.16.4\\arm-zephyr-eabi\\bin\\",
+              "env": [
+                {
+                  "name": "ZEPHYR_TOOLCHAIN_VARIANT",
+                  "value": "zephyr",
+                  "usepath": false,
+                  "append": false
+                },
+                {
+                  "name": "ZEPHYR_SDK_INSTALL_DIR",
+                  "suffix": "zephyr-sdk-0.16.4",
+                  "usepath": true,
+                  "append": false
+                }
+              ]
+            },
+            {
+              "name": "toolchain",
+              "filename": "toolchain_windows-x86_64_arm-zephyr-eabi.zip",
+              "url": "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.4/toolchain_windows-x86_64_arm-zephyr-eabi.zip",
+              "md5": "1786d58c03f3e380d683b1e5ded45131",
+              "suffix": "zephyr-sdk-0.16.4\\arm-zephyr-eabi\\bin\\",
+              "clear_target": false,
+              "copy_to_subfolder": "zephyr-sdk-0.16.4"
+            }
+          ]
+        },
+        {
+          "name": "zephyr-sdk-0.15.1",
+          "downloads": [
+            {
+              "name": "toolchain",
+              "filename": "zephyr-sdk-0.15.1_windows-x86_64_minimal.zip",
+              "url": "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.1/zephyr-sdk-0.15.1_windows-x86_64_minimal.zip",
+              "md5": "4c73427373995d1ac53412383a2f6610",
+              "suffix": "zephyr-sdk-0.15.1\\arm-zephyr-eabi\\bin\\",
+              "env": [
+                {
+                  "name": "ZEPHYR_TOOLCHAIN_VARIANT",
+                  "value": "zephyr",
+                  "usepath": false,
+                  "append": false
+                },
+                {
+                  "name": "ZEPHYR_SDK_INSTALL_DIR",
+                  "suffix": "zephyr-sdk-0.15.1",
+                  "usepath": true,
+                  "append": false
+                }
+              ]
+            },
+            {
+              "name": "toolchain",
+              "filename": "toolchain_windows-x86_64_arm-zephyr-eabi.zip",
+              "url": "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.1/toolchain_windows-x86_64_arm-zephyr-eabi.zip",
+              "md5": "1786d58c03f3e380d683b1e5ded45131",
+              "suffix": "zephyr-sdk-0.15.1\\arm-zephyr-eabi\\bin\\",
+              "clear_target": false,
+              "copy_to_subfolder": "zephyr-sdk-0.15.1"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "darwin": [
+    {
+      "arch": "x64",
+      "downloads": [
+        {
+          "name": "zephyr-tools",
+          "filename": "zephyr-tools-0.1.7-x86_64-apple-darwin.tar.gz",
+          "url": "https://github.com/circuitdojo/zephyr-tools-cli/releases/download/0.1.7/zephyr-tools-0.1.7-x86_64-apple-darwin.tar.gz",
+          "md5": "a2eaad10e8f4e29708a9bfe4193a61ed"
+        },
+        {
+          "name": "newtmgr",
+          "filename": "newtmgr.zip",
+          "url": "https://docs.jaredwolff.com/files/newtmgr/darwin/newtmgr.zip",
+          "md5": "7a707d8e518d46d92758a7b1b87366ed"
+        },
+        {
+          "name": "ninja",
+          "filename": "ninja-mac.zip",
+          "url": "https://github.com/ninja-build/ninja/releases/download/v1.10.2/ninja-mac.zip",
+          "md5": "4ac3da15e1ace3a0f846021e018a3acd"
+        },
+        {
+          "name": "cmake",
+          "filename": "cmake-3.22.0-macos-universal.tar.gz",
+          "url": "https://github.com/Kitware/CMake/releases/download/v3.22.0/cmake-3.22.0-macos-universal.tar.gz",
+          "md5": "438fc508b37b70a1d1bb112a4ffd4ad7",
+          "suffix": "cmake-3.22.0-macos-universal/CMake.app/Contents/bin/"
+        }
+      ],
+      "toolchains": [
+        {
+          "name": "zephyr-sdk-0.16.4 (latest)",
+          "downloads": [
+            {
+              "name": "toolchain",
+              "filename": "zephyr-sdk-0.16.4_macos-x86_64_minimal.tar.xz",
+              "url": "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.4/zephyr-sdk-0.16.4_macos-x86_64_minimal.tar.xz",
+              "md5": "4771443abfc72c1442a2cdf01034ab95",
+              "suffix": "zephyr-sdk-0.16.4/arm-zephyr-eabi/bin/",
+              "env": [
+                {
+                  "name": "ZEPHYR_TOOLCHAIN_VARIANT",
+                  "value": "zephyr",
+                  "usepath": false,
+                  "append": false
+                },
+                {
+                  "name": "ZEPHYR_SDK_INSTALL_DIR",
+                  "suffix": "zephyr-sdk-0.16.4",
+                  "usepath": true,
+                  "append": false
+                }
+              ],
+              "cmd": [
+                {
+                  "cmd": "zephyr-sdk-0.16.4/setup.sh -t arm-zephyr-eabi",
+                  "usepath": true
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "zephyr-sdk-0.15.1",
+          "downloads": [
+            {
+              "name": "toolchain",
+              "filename": "zephyr-sdk-0.15.1_macos-x86_64_minimal.tar.gz",
+              "url": "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.1/zephyr-sdk-0.15.1_macos-x86_64_minimal.tar.gz",
+              "md5": "2e6900c9ea1d03fbf67cd784e18f53bf",
+              "suffix": "zephyr-sdk-0.15.1/arm-zephyr-eabi/bin/",
+              "env": [
+                {
+                  "name": "ZEPHYR_TOOLCHAIN_VARIANT",
+                  "value": "zephyr",
+                  "usepath": false,
+                  "append": false
+                },
+                {
+                  "name": "ZEPHYR_SDK_INSTALL_DIR",
+                  "suffix": "zephyr-sdk-0.15.1",
+                  "usepath": true,
+                  "append": false
+                }
+              ],
+              "cmd": [
+                {
+                  "cmd": "zephyr-sdk-0.15.1/setup.sh -t arm-zephyr-eabi",
+                  "usepath": true
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "arch": "arm64",
+      "downloads": [
+        {
+          "name": "zephyr-tools",
+          "filename": "zephyr-tools-0.1.7-aarch64-apple-darwin.tar.gz",
+          "url": "https://github.com/circuitdojo/zephyr-tools-cli/releases/download/0.1.7/zephyr-tools-0.1.7-aarch64-apple-darwin.tar.gz",
+          "md5": "8649a82eb65f83d90b937d3065764bbc"
+        },
+        {
+          "name": "newtmgr",
+          "filename": "newtmgr.zip",
+          "url": "https://docs.jaredwolff.com/files/newtmgr/darwin/newtmgr.zip",
+          "md5": "7a707d8e518d46d92758a7b1b87366ed"
+        },
+        {
+          "name": "cmake",
+          "filename": "cmake-3.22.0-macos-universal.tar.gz",
+          "url": "https://github.com/Kitware/CMake/releases/download/v3.22.0/cmake-3.22.0-macos-universal.tar.gz",
+          "md5": "438fc508b37b70a1d1bb112a4ffd4ad7",
+          "suffix": "cmake-3.22.0-macos-universal/CMake.app/Contents/bin/"
+        }
+      ],
+      "toolchains": [
+        {
+          "name": "zephyr-sdk-0.16.4 (latest)",
+          "downloads": [
+            {
+              "name": "toolchain",
+              "filename": "zephyr-sdk-0.16.4_macos-aarch64_minimal.tar.xz",
+              "url": "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.4/zephyr-sdk-0.16.4_macos-aarch64_minimal.tar.xz",
+              "md5": "4aa2aa3b8313e04dd93a8bbee4b31754",
+              "suffix": "zephyr-sdk-0.16.4/arm-zephyr-eabi/bin/",
+              "env": [
+                {
+                  "name": "ZEPHYR_TOOLCHAIN_VARIANT",
+                  "value": "zephyr",
+                  "usepath": false,
+                  "append": false
+                },
+                {
+                  "name": "ZEPHYR_SDK_INSTALL_DIR",
+                  "suffix": "zephyr-sdk-0.16.4",
+                  "usepath": true,
+                  "append": false
+                }
+              ],
+              "cmd": [
+                {
+                  "cmd": "zephyr-sdk-0.16.4/setup.sh -t arm-zephyr-eabi",
+                  "usepath": true
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "zephyr-sdk-0.15.1",
+          "downloads": [
+            {
+              "name": "toolchain",
+              "filename": "zephyr-sdk-0.15.1_macos-aarch64_minimal.tar.gz",
+              "url": "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.1/zephyr-sdk-0.15.1_macos-aarch64_minimal.tar.gz",
+              "md5": "6b0d6e08ad5753a29d96df4d6ccfed72",
+              "suffix": "zephyr-sdk-0.15.1/arm-zephyr-eabi/bin/",
+              "env": [
+                {
+                  "name": "ZEPHYR_TOOLCHAIN_VARIANT",
+                  "value": "zephyr",
+                  "usepath": false,
+                  "append": false
+                },
+                {
+                  "name": "ZEPHYR_SDK_INSTALL_DIR",
+                  "suffix": "zephyr-sdk-0.15.1",
+                  "usepath": true,
+                  "append": false
+                }
+              ],
+              "cmd": [
+                {
+                  "cmd": "zephyr-sdk-0.15.1/setup.sh -t arm-zephyr-eabi",
+                  "usepath": true
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "linux": [
+    {
+      "arch": "x64",
+      "downloads": [
+        {
+          "name": "zephyr-tools",
+          "filename": "zephyr-tools-0.1.7-x86_64-unknown-linux-gnu.tar.gz",
+          "url": "https://github.com/circuitdojo/zephyr-tools-cli/releases/download/0.1.7/zephyr-tools-0.1.7-x86_64-unknown-linux-gnu.tar.gz",
+          "md5": "efca3005895e1437193b3b03f9abf561"
+        },
+        {
+          "name": "newtmgr",
+          "filename": "newtmgr.zip",
+          "url": "https://docs.jaredwolff.com/files/newtmgr/linux/newtmgr.zip",
+          "md5": "9900ec263d39264787903688cdefeed1"
+        },
+        {
+          "name": "ninja",
+          "filename": "ninja-linux.zip",
+          "url": "https://github.com/ninja-build/ninja/releases/download/v1.10.2/ninja-linux.zip",
+          "md5": "817e12e06e2463aeb5cb4e1d19ced606"
+        },
+        {
+          "name": "cmake",
+          "filename": "cmake-3.22.0-linux-x86_64.tar.gz",
+          "url": "https://github.com/Kitware/CMake/releases/download/v3.22.0/cmake-3.22.0-linux-x86_64.tar.gz",
+          "md5": "5537bbc683e364e5408a393a737f53a1",
+          "suffix": "cmake-3.22.0-linux-x86_64/bin/"
+        }
+      ],
+      "toolchains": [
+        {
+          "name": "zephyr-sdk-0.16.4 (latest)",
+          "downloads": [
+            {
+              "name": "toolchain",
+              "filename": "zephyr-sdk-0.16.4_linux-x86_64_minimal.tar.xz",
+              "url": "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.4/zephyr-sdk-0.16.4_linux-x86_64_minimal.tar.xz",
+              "md5": "5f10ac5111476d4e069b52f07aa3f4d5",
+              "suffix": "zephyr-sdk-0.16.4/arm-zephyr-eabi/bin/",
+              "env": [
+                {
+                  "name": "ZEPHYR_TOOLCHAIN_VARIANT",
+                  "value": "zephyr",
+                  "usepath": false,
+                  "append": false
+                },
+                {
+                  "name": "ZEPHYR_SDK_INSTALL_DIR",
+                  "suffix": "zephyr-sdk-0.16.4",
+                  "usepath": true,
+                  "append": false
+                }
+              ]
+            },
+            {
+              "name": "toolchain",
+              "filename": "toolchain_linux-x86_64_arm-zephyr-eabi.tar.xz",
+              "url": "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.4/toolchain_linux-x86_64_arm-zephyr-eabi.tar.xz",
+              "md5": "4386d940c085670fc54480eb7eaebff8",
+              "suffix": "zephyr-sdk-0.16.4\\arm-zephyr-eabi\\bin\\",
+              "clear_target": false,
+              "copy_to_subfolder": "zephyr-sdk-0.16.4"
+            }
+          ]
+        },
+        {
+          "name": "zephyr-sdk-0.15.1",
+          "downloads": [
+            {
+              "name": "toolchain",
+              "filename": "zephyr-sdk-0.15.1_linux-x86_64_minimal.tar.gz",
+              "url": "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.1/zephyr-sdk-0.15.1_linux-x86_64_minimal.tar.gz",
+              "md5": "e74588785a291867feacf14134aaec61",
+              "suffix": "zephyr-sdk-0.15.1/arm-zephyr-eabi/bin/",
+              "env": [
+                {
+                  "name": "ZEPHYR_TOOLCHAIN_VARIANT",
+                  "value": "zephyr",
+                  "usepath": false,
+                  "append": false
+                },
+                {
+                  "name": "ZEPHYR_SDK_INSTALL_DIR",
+                  "suffix": "zephyr-sdk-0.15.1",
+                  "usepath": true,
+                  "append": false
+                }
+              ]
+            },
+            {
+              "name": "toolchain",
+              "filename": "toolchain_linux-x86_64_arm-zephyr-eabi.tar.gz",
+              "url": "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.1/toolchain_linux-x86_64_arm-zephyr-eabi.tar.gz",
+              "md5": "bf75b7db76bd5ad260be7e708e29c90d",
+              "suffix": "zephyr-sdk-0.15.1\\arm-zephyr-eabi\\bin\\",
+              "clear_target": false,
+              "copy_to_subfolder": "zephyr-sdk-0.15.1"
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/manifest/manifest.json
+++ b/manifest/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": 13,
+  "version": 14,
   "win32": [
     {
       "arch": "x64",
@@ -8,7 +8,7 @@
           "name": "zephyr-tools",
           "filename": "zephyr-tools-0.1.7-x86_64-pc-windows-msvc.zip",
           "url": "https://github.com/circuitdojo/zephyr-tools-cli/releases/download/0.1.7/zephyr-tools-0.1.7-x86_64-pc-windows-msvc.zip",
-          "md5": "3d3504f84fe98e645b27fb6c63e761fa"
+          "md5": "ab0154c2923f7f89ec025edd020785e4"
         },
         {
           "name": "newtmgr",
@@ -32,13 +32,13 @@
       ],
       "toolchains": [
         {
-          "name": "zephyr-sdk-0.16.4 (latest)",
+          "name": "zephyr-sdk-0.16.4",
           "downloads": [
             {
               "name": "toolchain",
-              "filename": "zephyr-sdk-0.16.4_windows-x86_64_minimal.zip",
-              "url": "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.4/zephyr-sdk-0.16.4_windows-x86_64_minimal.zip",
-              "md5": "4c73427373995d1ac53412383a2f6610",
+              "filename": "zephyr-sdk-0.16.4_windows-x86_64_minimal.7z",
+              "url": "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.4/zephyr-sdk-0.16.4_windows-x86_64_minimal.7z",
+              "md5": "fbf2ffa00c77227537514fa43075607f",
               "suffix": "zephyr-sdk-0.16.4\\arm-zephyr-eabi\\bin\\",
               "env": [
                 {
@@ -57,9 +57,9 @@
             },
             {
               "name": "toolchain",
-              "filename": "toolchain_windows-x86_64_arm-zephyr-eabi.zip",
-              "url": "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.4/toolchain_windows-x86_64_arm-zephyr-eabi.zip",
-              "md5": "1786d58c03f3e380d683b1e5ded45131",
+              "filename": "toolchain_windows-x86_64_arm-zephyr-eabi.7z",
+              "url": "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.4/toolchain_windows-x86_64_arm-zephyr-eabi.7z",
+              "md5": "37e3d358aae2ee055f34b97fd24aadd5",
               "suffix": "zephyr-sdk-0.16.4\\arm-zephyr-eabi\\bin\\",
               "clear_target": false,
               "copy_to_subfolder": "zephyr-sdk-0.16.4"
@@ -136,7 +136,7 @@
       ],
       "toolchains": [
         {
-          "name": "zephyr-sdk-0.16.4 (latest)",
+          "name": "zephyr-sdk-0.16.4",
           "downloads": [
             {
               "name": "toolchain",
@@ -226,7 +226,7 @@
       ],
       "toolchains": [
         {
-          "name": "zephyr-sdk-0.16.4 (latest)",
+          "name": "zephyr-sdk-0.16.4",
           "downloads": [
             {
               "name": "toolchain",
@@ -324,7 +324,7 @@
       ],
       "toolchains": [
         {
-          "name": "zephyr-sdk-0.16.4 (latest)",
+          "name": "zephyr-sdk-0.16.4",
           "downloads": [
             {
               "name": "toolchain",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,17 @@
 {
   "name": "zephyr-tools",
-  "version": "0.1.28",
+  "version": "0.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "zephyr-tools",
-      "version": "0.1.28",
+      "version": "0.2.3",
+      "license": "Apache-2.0",
       "dependencies": {
+        "7zip-bin": "^5.2.0",
         "fs-extra": "^10.0.0",
+        "node-7z": "^3.0.0",
         "node-stream-zip": "^1.15.0",
         "typed-rest-client": "^1.8.6"
       },
@@ -17,6 +20,7 @@
         "@types/glob": "^7.1.3",
         "@types/mocha": "^8.0.4",
         "@types/node": "^12.11.7",
+        "@types/node-7z": "^2.1.8",
         "@types/vscode": "^1.52.0",
         "@typescript-eslint/eslint-plugin": "^4.9.0",
         "@typescript-eslint/parser": "^4.9.0",
@@ -270,6 +274,15 @@
       "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
       "dev": true
     },
+    "node_modules/@types/node-7z": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@types/node-7z/-/node-7z-2.1.8.tgz",
+      "integrity": "sha512-VjiU7yEbczNc3EFKN4GJcAUqAMkn92P/92r6ARjMSXEdixunMD9lC79mTX81vKxTlNYXuvCJ7zvnzlDbFTt2Vw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/vscode": {
       "version": "1.73.1",
       "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.73.1.tgz",
@@ -438,6 +451,11 @@
       "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
       "dev": true
+    },
+    "node_modules/7zip-bin": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-5.2.0.tgz",
+      "integrity": "sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A=="
     },
     "node_modules/acorn": {
       "version": "7.4.1",
@@ -791,7 +809,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -1679,11 +1696,36 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.defaultsdeep": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.defaultsdeep/-/lodash.defaultsdeep-4.6.1.tgz",
+      "integrity": "sha512-3j8wdDzYuWO3lM3Reg03MuQR957t287Rpcxp1njpEa8oDrikb+FwGdW3n+FELh/A6qib6yPit0j/pv9G/yeAqA=="
+    },
+    "node_modules/lodash.defaultto": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaultto/-/lodash.defaultto-4.14.0.tgz",
+      "integrity": "sha512-G6tizqH6rg4P5j32Wy4Z3ZIip7OfG8YWWlPFzUFGcYStH1Ld0l1tWs6NevEQNEDnO1M3NZYjuHuraaFSN5WqeQ=="
+    },
+    "node_modules/lodash.flattendeep": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+      "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ=="
+    },
+    "node_modules/lodash.isempty": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+      "integrity": "sha512-oKMuF3xEeqDltrGMfDxAPGIVMSSRv8tbRSODbrs4KGsRRLEhrW8N8Rd4DRgB2+621hY8A8XwwrTVhXWpxFvMzg=="
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/lodash.negate": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/lodash.negate/-/lodash.negate-3.0.2.tgz",
+      "integrity": "sha512-JGJYYVslKYC0tRMm/7igfdHulCjoXjoganRNWM8AgS+RXfOvFnPkOveDhPI65F9aAypCX9QEEQoBqWf7Q6uAeA=="
     },
     "node_modules/lodash.truncate": {
       "version": "4.4.2",
@@ -1920,8 +1962,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/nanoid": {
       "version": "3.1.20",
@@ -1941,6 +1982,23 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
+    "node_modules/node-7z": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/node-7z/-/node-7z-3.0.0.tgz",
+      "integrity": "sha512-KIznWSxIkOYO/vOgKQfJEaXd7rgoFYKZbaurainCEdMhYc7V7mRHX+qdf2HgbpQFcdJL/Q6/XOPrDLoBeTfuZA==",
+      "dependencies": {
+        "debug": "^4.3.2",
+        "lodash.defaultsdeep": "^4.6.1",
+        "lodash.defaultto": "^4.14.0",
+        "lodash.flattendeep": "^4.4.0",
+        "lodash.isempty": "^4.4.0",
+        "lodash.negate": "^3.0.2",
+        "normalize-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/node-stream-zip": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/node-stream-zip/-/node-stream-zip-1.15.0.tgz",
@@ -1957,7 +2015,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2303,9 +2360,9 @@
       ]
     },
     "node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -2740,9 +2797,9 @@
       }
     },
     "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -3049,6 +3106,15 @@
       "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
       "dev": true
     },
+    "@types/node-7z": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@types/node-7z/-/node-7z-2.1.8.tgz",
+      "integrity": "sha512-VjiU7yEbczNc3EFKN4GJcAUqAMkn92P/92r6ARjMSXEdixunMD9lC79mTX81vKxTlNYXuvCJ7zvnzlDbFTt2Vw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/vscode": {
       "version": "1.73.1",
       "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.73.1.tgz",
@@ -3143,6 +3209,11 @@
       "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
       "dev": true
+    },
+    "7zip-bin": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-5.2.0.tgz",
+      "integrity": "sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A=="
     },
     "acorn": {
       "version": "7.4.1",
@@ -3410,7 +3481,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "requires": {
         "ms": "2.1.2"
       }
@@ -4076,11 +4146,36 @@
         "p-locate": "^5.0.0"
       }
     },
+    "lodash.defaultsdeep": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.defaultsdeep/-/lodash.defaultsdeep-4.6.1.tgz",
+      "integrity": "sha512-3j8wdDzYuWO3lM3Reg03MuQR957t287Rpcxp1njpEa8oDrikb+FwGdW3n+FELh/A6qib6yPit0j/pv9G/yeAqA=="
+    },
+    "lodash.defaultto": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaultto/-/lodash.defaultto-4.14.0.tgz",
+      "integrity": "sha512-G6tizqH6rg4P5j32Wy4Z3ZIip7OfG8YWWlPFzUFGcYStH1Ld0l1tWs6NevEQNEDnO1M3NZYjuHuraaFSN5WqeQ=="
+    },
+    "lodash.flattendeep": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+      "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ=="
+    },
+    "lodash.isempty": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+      "integrity": "sha512-oKMuF3xEeqDltrGMfDxAPGIVMSSRv8tbRSODbrs4KGsRRLEhrW8N8Rd4DRgB2+621hY8A8XwwrTVhXWpxFvMzg=="
+    },
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "lodash.negate": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/lodash.negate/-/lodash.negate-3.0.2.tgz",
+      "integrity": "sha512-JGJYYVslKYC0tRMm/7igfdHulCjoXjoganRNWM8AgS+RXfOvFnPkOveDhPI65F9aAypCX9QEEQoBqWf7Q6uAeA=="
     },
     "lodash.truncate": {
       "version": "4.4.2",
@@ -4260,8 +4355,7 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "nanoid": {
       "version": "3.1.20",
@@ -4275,6 +4369,20 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
+    "node-7z": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/node-7z/-/node-7z-3.0.0.tgz",
+      "integrity": "sha512-KIznWSxIkOYO/vOgKQfJEaXd7rgoFYKZbaurainCEdMhYc7V7mRHX+qdf2HgbpQFcdJL/Q6/XOPrDLoBeTfuZA==",
+      "requires": {
+        "debug": "^4.3.2",
+        "lodash.defaultsdeep": "^4.6.1",
+        "lodash.defaultto": "^4.14.0",
+        "lodash.flattendeep": "^4.4.0",
+        "lodash.isempty": "^4.4.0",
+        "lodash.negate": "^3.0.2",
+        "normalize-path": "^3.0.0"
+      }
+    },
     "node-stream-zip": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/node-stream-zip/-/node-stream-zip-1.15.0.tgz",
@@ -4283,8 +4391,7 @@
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
     },
     "object-inspect": {
       "version": "1.12.2",
@@ -4505,9 +4612,9 @@
       "dev": true
     },
     "semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
       "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
@@ -4846,9 +4953,9 @@
       }
     },
     "word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true
     },
     "workerpool": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "zephyr-tools",
   "displayName": "Circuit Dojo Zephyr SDK Tools",
   "description": "Used for building your Zephyr projects.",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "license": "Apache-2.0",
   "publisher": "circuitdojo",
   "icon": "img/bulb.png",
@@ -118,6 +118,7 @@
     "@types/glob": "^7.1.3",
     "@types/mocha": "^8.0.4",
     "@types/node": "^12.11.7",
+    "@types/node-7z": "^2.1.8",
     "@types/vscode": "^1.52.0",
     "@typescript-eslint/eslint-plugin": "^4.9.0",
     "@typescript-eslint/parser": "^4.9.0",
@@ -128,7 +129,9 @@
     "vscode-test": "^1.4.1"
   },
   "dependencies": {
+    "7zip-bin": "^5.2.0",
     "fs-extra": "^10.0.0",
+    "node-7z": "^3.0.0",
     "node-stream-zip": "^1.15.0",
     "typed-rest-client": "^1.8.6"
   },


### PR DESCRIPTION
Changed:

- Fixed manifest entries for Windows
- Added 7z support
- Updating pkg dependencies
- `process_download` now returns to avoid continuing if error