### PR TITLE
Changed default zephyr version to v3.6.0

### DIFF
--- a/templates/vanilla/west.yml
+++ b/templates/vanilla/west.yml
@@ -6,7 +6,7 @@ manifest:
     - name: zephyr
       repo-path: zephyr
       remote: zephyrproject
-      revision: v3.3.0
+      revision: v3.6.0
       import:
         path-prefix: deps
   self:


### PR DESCRIPTION
Upgrading the default zephyr version to v3.6.0